### PR TITLE
Created PVs are owned by their respective Nodes

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -31,7 +31,7 @@ import (
 
 	"hash/fnv"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
@@ -165,6 +165,7 @@ type LocalPVConfig struct {
 	MountOptions    []string
 	FsType          *string
 	Labels          map[string]string
+	OwnerReference  *metav1.OwnerReference
 }
 
 // BuildConfigFromFlags being defined to enable mocking during unit testing
@@ -209,6 +210,9 @@ func CreateLocalPVSpec(config *LocalPVConfig) *v1.PersistentVolume {
 			Labels: config.Labels,
 			Annotations: map[string]string{
 				AnnProvisionedBy: config.ProvisionerName,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				*config.OwnerReference,
 			},
 		},
 		Spec: v1.PersistentVolumeSpec{

--- a/pkg/deleter/deleter_test.go
+++ b/pkg/deleter/deleter_test.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/util"
 
 	batch_v1 "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -42,6 +42,8 @@ import (
 const (
 	testHostDir      = "/mnt/disks"
 	testMountDir     = "/discoveryPath"
+	testNodeName     = "somehost.acme.com"
+	testNodeUID      = "d9607e19-f88f-11e6-a518-42010a800195"
 	testStorageClass = "sc1"
 )
 
@@ -558,6 +560,11 @@ func testSetup(t *testing.T, config *testConfig, cleanupCmd []string, useJobForC
 			Name:         pvName,
 			HostPath:     fakePath,
 			StorageClass: testStorageClass,
+			OwnerReference: &meta_v1.OwnerReference{
+				Kind: "Node",
+				Name: testNodeName,
+				UID:  testNodeUID,
+			},
 		}
 		// If volume mode has been explicitly specified in the volume config, then explicitly set it in the PV.
 		switch vol.VolumeMode {
@@ -598,7 +605,10 @@ func testSetup(t *testing.T, config *testConfig, cleanupCmd []string, useJobForC
 				BlockCleanerCommand: cleanupCmd,
 			},
 		},
-		Node:              &v1.Node{ObjectMeta: meta_v1.ObjectMeta{Name: "somehost.acme.com"}},
+		Node: &v1.Node{ObjectMeta: meta_v1.ObjectMeta{
+			Name: testNodeName,
+			UID:  testNodeUID,
+		}},
 		UseJobForCleaning: useJobForCleaning,
 		JobContainerImage: containerImage,
 		Namespace:         ns,

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -123,9 +123,10 @@ func generateOwnerReference(node *v1.Node) (*metav1.OwnerReference, error) {
 	}
 
 	return &metav1.OwnerReference{
-		Kind: "Node",
-		Name: node.GetName(),
-		UID:  node.UID,
+		APIVersion: "v1",
+		Kind:       "Node",
+		Name:       node.GetName(),
+		UID:        node.UID,
 	}, nil
 }
 

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -27,7 +27,8 @@ import (
 	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/common"
 	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/metrics"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	storagev1listers "k8s.io/client-go/listers/storage/v1"
 	"k8s.io/client-go/tools/cache"
 	esUtil "sigs.k8s.io/sig-storage-lib-external-provisioner/util"
@@ -45,6 +46,7 @@ type Discoverer struct {
 	nodeAffinityAnn string
 	nodeAffinity    *v1.VolumeNodeAffinity
 	classLister     storagev1listers.StorageClassLister
+	ownerReference  *metav1.OwnerReference
 }
 
 // NewDiscoverer creates a Discoverer object that will scan through
@@ -72,6 +74,12 @@ func NewDiscoverer(config *common.RuntimeConfig, cleanupTracker *deleter.Cleanup
 		labelMap[labelName] = labelValue
 	}
 
+	// Generate owner reference
+	ownerRef, err := generateOwnerReference(config.Node)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to generate owner reference: %v", err)
+	}
+
 	if config.UseAlphaAPI {
 		nodeAffinity, err := generateNodeAffinity(config.Node)
 		if err != nil {
@@ -87,7 +95,8 @@ func NewDiscoverer(config *common.RuntimeConfig, cleanupTracker *deleter.Cleanup
 			Labels:          labelMap,
 			CleanupTracker:  cleanupTracker,
 			classLister:     sharedInformer.Lister(),
-			nodeAffinityAnn: tmpAnnotations[common.AlphaStorageNodeAffinityAnnotation]}, nil
+			nodeAffinityAnn: tmpAnnotations[common.AlphaStorageNodeAffinityAnnotation],
+			ownerReference:  ownerRef}, nil
 	}
 
 	volumeNodeAffinity, err := generateVolumeNodeAffinity(config.Node)
@@ -100,7 +109,24 @@ func NewDiscoverer(config *common.RuntimeConfig, cleanupTracker *deleter.Cleanup
 		Labels:         labelMap,
 		CleanupTracker: cleanupTracker,
 		classLister:    sharedInformer.Lister(),
-		nodeAffinity:   volumeNodeAffinity}, nil
+		nodeAffinity:   volumeNodeAffinity,
+		ownerReference: ownerRef}, nil
+}
+
+func generateOwnerReference(node *v1.Node) (*metav1.OwnerReference, error) {
+	if node.GetName() == "" {
+		return nil, fmt.Errorf("Node does not have name")
+	}
+
+	if node.GetUID() == "" {
+		return nil, fmt.Errorf("Node does not have UID")
+	}
+
+	return &metav1.OwnerReference{
+		Kind: "Node",
+		Name: node.GetName(),
+		UID:  node.UID,
+	}, nil
 }
 
 func generateNodeAffinity(node *v1.Node) (*v1.NodeAffinity, error) {
@@ -314,6 +340,7 @@ func (d *Discoverer) createPV(file, class string, reclaimPolicy v1.PersistentVol
 		VolumeMode:      volMode,
 		Labels:          d.Labels,
 		MountOptions:    mountOptions,
+		OwnerReference:  d.ownerReference,
 	}
 
 	if d.UseAlphaAPI {


### PR DESCRIPTION
When a `PV` is created it is set to be dependent of the `Node` backing it.
When the `Node` is deleted the `PV` is also deleted by the k8s garbage collector.